### PR TITLE
List package "files" inside package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /lib
 /node_modules
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -38,5 +38,15 @@
     }
   },
   "author": "spion",
-  "license": "ISC"
+  "license": "ISC",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "lib/**/*.js",
+    "lib/**/*.js.map",
+    "lib/**/*.d.ts",
+    "lib/**/*.mjs",
+    "lib/**/*.mjs.map",
+    "lib/**/*.d.mts"
+  ]
 }


### PR DESCRIPTION
This optimizes the size of the published package. Currently, there is the whole repo published to npm.