### PR TITLE
fix: mark packages as DCE capable

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
 		"lib/**/*.mjs.map",
 		"lib/**/*.d.mts"
 	],
+  "sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/ionic-solidjs/ionic-solidjs.git",

--- a/packages/ionicons/package.json
+++ b/packages/ionicons/package.json
@@ -44,6 +44,7 @@
 		"lib/**/*.mjs.map",
 		"lib/**/*.d.mts"
 	],
+  "sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/spion/ionic-solidjs.git",

--- a/packages/ionicons/vite.config.ts
+++ b/packages/ionicons/vite.config.ts
@@ -1,12 +1,10 @@
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
-import solidPlugin from 'vite-plugin-solid';
 import pkg from './package.json';
 
 export default defineConfig({
 	plugins: [
-		solidPlugin({ solid: { generate: 'dom' } }),
 		dts({
 			insertTypesEntry: true,
 		}),


### PR DESCRIPTION
If this is not present rollup will not attempt to do any tree-shaking.